### PR TITLE
Bug q mismatch

### DIFF
--- a/DeployServerGRPC/DeployerExportServiceImpl.cpp
+++ b/DeployServerGRPC/DeployerExportServiceImpl.cpp
@@ -111,7 +111,6 @@ int ec::rpc::DeployerExportServiceImpl::insertPodSpec(const ec::rpc::ExportPodSp
 
     //std::cout << "sc_id to insertPodSpec: " << SubContainer::ContainerId(pod->cgroup_id(), pod->node_ip()) << std::endl;
     std::cout << "sc_id to insertPodSpec: " << SubContainer::ContainerId(pod->cgroup_id(), pod->node_ip()) << std::endl;
-    std::cout << "insertpodspec cgID: " << pod->cgroup_id() << std::endl;
 
     dep_pod_lock.lock();
     auto inserted = deployedPods.emplace(

--- a/Manager.cpp
+++ b/Manager.cpp
@@ -357,9 +357,6 @@ int ec::Manager::handle_add_cgroup_to_ec(const ec::msg_t *req, ec::msg_t *res, u
     //Check quota
     uint64_t quota;
     int update_quota = determine_quota_for_new_pod(req->rsrc_amnt, quota);
-    std::cout << "init pod rsrc amnt: " << req->rsrc_amnt << std::endl;
-    std::cout << "init pod updated quota: " << quota << std::endl;
-    std::cout << "init pod thr: " << req->request << std::endl;
 
     auto *sc = _ec->create_new_sc(req->cgroup_id, ip, fd, quota, req->request); //update with throttle and quota
     if (!sc) {

--- a/Server.cpp
+++ b/Server.cpp
@@ -112,6 +112,7 @@ void ec::Server::handle_client_reqs(void *args) {
 //        std::cout << "num bytes read: " << num_bytes << std::endl;
         auto *req = reinterpret_cast<msg_t*>(buff_in);
         req->set_ip_from_net(client_ip); //this needs to be removed eventually
+//        req->set_ip_from_string("10.0.2.15"); //TODO: this needs to be changed. but here for testing merge
         auto *res = new msg_t(*req);
 //        std::cout << "received: " << *req << std::endl;
 //        ret = handle_req(req, res, arguments->cliaddr->sin_addr.s_addr, arguments->clifd);

--- a/stats/local/cpu_l.cpp
+++ b/stats/local/cpu_l.cpp
@@ -14,7 +14,7 @@ ec::local::stats::cpu::cpu()
 ec::local::stats::cpu::cpu(uint64_t _quota, uint32_t _nr_throttled)     //TODO: may need to fix here
     : quota(_quota), period(100000000), alloc_extra_slices(false),
     num_local_slices_requested(0), num_local_slices_acquired(0),
-    extra_runtime_to_give(0), nr_throttled(0),
+    extra_runtime_to_give(0), nr_throttled(_nr_throttled),
       rt_winstats(__WINDOW_STAT_SIZE_), th_winstats(__WINDOW_STAT_SIZE_),
       set_quota_flag(false) {}
 


### PR DESCRIPTION
issue with setting throttle value
note in gcm on init `req->request` actually holds the current number of pod throttles in the conntecting container
Fix in combination with this PR: https://github.com/gregcusack/EC-4.20.16/pull/26
Fixes issue: https://github.com/gregcusack/Distributed-Containers/issues/13